### PR TITLE
修改数据量大时,因为多次读取导致被覆盖的问题.

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -70,7 +70,7 @@ func (s *fakeMassiveDataPty) Read(p []byte) (int, error) {
 }
 
 func (s *fakeMassiveDataPty) Write(p []byte) (int, error) {
-	s.message = p
+	s.message = append(s.message, p...)
 	return len(p), nil
 }
 


### PR DESCRIPTION
修改数据量大时,因为多次读取导致被覆盖的问题.
应该将新数据追加到末尾,才能够正确地接收到完整的输出数据，而不会被截断